### PR TITLE
Proposed fix to bazaarvoice/dropwizard-webjars-bundle#6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/bazaarvoice/dropwizard/webjars/WebJarBundle.java
+++ b/src/main/java/com/bazaarvoice/dropwizard/webjars/WebJarBundle.java
@@ -12,21 +12,58 @@ import java.util.List;
 public class WebJarBundle implements Bundle {
     private CacheBuilder cacheBuilder = null;
     private List<String> packages = Lists.newArrayList(WebJarServlet.DEFAULT_MAVEN_GROUPS);
+    private String urlPrefix;
 
     public WebJarBundle() {
+
+        this(null, null, null);
+    }
+
+    public WebJarBundle(final String urlPrefix) {
+        this(urlPrefix, null, null);
     }
 
     public WebJarBundle(CacheBuilder builder) {
+
+        this(null, builder, null);
         cacheBuilder = builder;
+    }
+
+    public WebJarBundle(final String urlPrefix, CacheBuilder builder) {
+        this(urlPrefix, builder, null);
     }
 
     public WebJarBundle(String... additionalPackages) {
-        Collections.addAll(packages, additionalPackages);
+        this(null, null, additionalPackages);
+    }
+
+    public WebJarBundle(final String urlPrefix, String... additionalPackages) {
+        this(urlPrefix, null, additionalPackages);
     }
 
     public WebJarBundle(CacheBuilder builder, String... additionalPackages) {
+        this(null, builder, additionalPackages);
+    }
+
+    public WebJarBundle(final String urlPrefix, CacheBuilder builder, String... additionalPackages) {
+        this.urlPrefix = (urlPrefix == null? WebJarServlet.DEFAULT_URL_PREFIX : urlPrefix);
         cacheBuilder = builder;
-        Collections.addAll(packages, additionalPackages);
+        if(additionalPackages != null) {
+            Collections.addAll(packages, additionalPackages);
+        }
+
+    }
+
+    private String normalizedUrlPrefix() {
+        final StringBuilder pathBuilder = new StringBuilder();
+        if(! urlPrefix.startsWith("/")) {
+            pathBuilder.append('/');
+        }
+        pathBuilder.append(urlPrefix);
+        if(! urlPrefix.endsWith("/")) {
+            pathBuilder.append('/');
+        }
+        return pathBuilder.toString();
     }
 
     @Override
@@ -35,7 +72,7 @@ public class WebJarBundle implements Bundle {
 
     @Override
     public void run(Environment environment) {
-        WebJarServlet servlet = new WebJarServlet(cacheBuilder, packages);
-        environment.servlets().addServlet("webjars", servlet).addMapping(WebJarServlet.URL_PREFIX + "*");
+        WebJarServlet servlet = new WebJarServlet(cacheBuilder, packages, normalizedUrlPrefix());
+        environment.servlets().addServlet("webjars", servlet).addMapping(normalizedUrlPrefix() + "*");
     }
 }

--- a/src/test/java/com/bazaarvoice/dropwizard/webjars/TestWebJarServlet.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/webjars/TestWebJarServlet.java
@@ -16,6 +16,6 @@ public class TestWebJarServlet extends WebJarServlet {
     }
 
     public TestWebJarServlet() {
-        super(null, ImmutableList.copyOf(MAVEN_GROUPS));
+        super(null, ImmutableList.copyOf(MAVEN_GROUPS), WebJarServlet.DEFAULT_URL_PREFIX);
     }
 }

--- a/src/test/java/com/bazaarvoice/dropwizard/webjars/WebJarBundleTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/webjars/WebJarBundleTest.java
@@ -1,29 +1,51 @@
 package com.bazaarvoice.dropwizard.webjars;
 
 import io.dropwizard.setup.Environment;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import javax.servlet.ServletRegistration;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class WebJarBundleTest {
-    private final Environment environment = mock(Environment.class, RETURNS_DEEP_STUBS);
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private Environment environment;
+
+    @Captor
+    private ArgumentCaptor<String> pathCaptor;
 
     @Test
     public void testRegistersAtWebjarsPath() {
         new WebJarBundle().run(environment);
 
         ServletRegistration.Dynamic dynamic = environment.servlets().addServlet(eq("webjars"), notNull(WebJarServlet.class));
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(dynamic).addMapping(pathCaptor.capture());
 
         assertEquals("/webjars/*", pathCaptor.getValue());
+    }
+
+    @Test
+    public void testRegistersAtCustomPath() {
+        final String path = "path";
+        new WebJarBundle(path).run(environment);
+
+        ServletRegistration.Dynamic dynamic = environment.servlets().addServlet(eq("webjars"), notNull(WebJarServlet.class));
+        verify(dynamic).addMapping(pathCaptor.capture());
+
+        assertEquals("/" + path + "/*", pathCaptor.getValue());
     }
 }

--- a/src/test/java/com/bazaarvoice/dropwizard/webjars/WebJarServletCustomPathTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/webjars/WebJarServletCustomPathTest.java
@@ -1,0 +1,67 @@
+package com.bazaarvoice.dropwizard.webjars;
+
+import com.google.common.base.Throwables;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlet.ServletTester;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebJarServletCustomPathTest {
+
+    public static final String CUSTOM_PATH = "/custom/";
+    private final ServletTester servletTester = new ServletTester();
+    private final WebJarServlet webJarServlet = new WebJarServlet(null,
+                                                                  Arrays.asList(WebJarServlet.DEFAULT_MAVEN_GROUPS), CUSTOM_PATH);
+
+    @Before
+    public void setup() throws Exception {
+        servletTester.addServlet(new ServletHolder(webJarServlet), CUSTOM_PATH + "*");
+        servletTester.start();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        servletTester.stop();
+        TestWebJarServlet.resetMavenGroups();
+    }
+
+    @Test
+    public void testBootstrapAtCustomPath() throws Exception {
+        HttpTester.Response response = get("bootstrap/css/bootstrap.css");
+        assertEquals(200, response.getStatus());
+
+    }
+
+    private HttpTester.Request request(String url) {
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setMethod("GET");
+        request.setVersion("HTTP/1.0");
+        request.setURI(CUSTOM_PATH + url);
+        return request;
+    }
+
+    private HttpTester.Response get(String url) {
+        HttpTester.Request request = request(url);
+        return get(request);
+    }
+
+    private HttpTester.Response get(HttpTester.Request request) {
+        HttpTester.Response response;
+        try {
+            ByteBuffer raw = request.generate();
+            ByteBuffer responses = servletTester.getResponses(raw);
+            response = HttpTester.parseResponse(responses);
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+
+        return response;
+    }
+}

--- a/src/test/java/com/bazaarvoice/dropwizard/webjars/WebJarServletTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/webjars/WebJarServletTest.java
@@ -21,7 +21,7 @@ public class WebJarServletTest {
 
     @Before
     public void setup() throws Exception {
-        servletTester.addServlet(TestWebJarServlet.class, TestWebJarServlet.URL_PREFIX + "*");
+        servletTester.addServlet(TestWebJarServlet.class, TestWebJarServlet.DEFAULT_URL_PREFIX + "*");
         servletTester.start();
     }
 
@@ -148,7 +148,7 @@ public class WebJarServletTest {
         HttpTester.Request request = HttpTester.newRequest();
         request.setMethod("GET");
         request.setVersion("HTTP/1.0");
-        request.setURI(WebJarServlet.URL_PREFIX + url);
+        request.setURI(WebJarServlet.DEFAULT_URL_PREFIX + url);
         return request;
     }
 


### PR DESCRIPTION
Added 'urlPrefix' property and renamed the URL_PREFIX constant in WebJarServlet to DEFAULT_URL_PREFIX.

If an URL PREFIX is not defined when the Bundle is created, it will fall back to the DEFAULT value. Thus, this change should not break anything
